### PR TITLE
travis install per instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python: 2.7
 cache: false
 
 install:
-  - pip install .
+  - python setup.py install
 
 script:
   - python test.py


### PR DESCRIPTION
Use `python setup.py install` instead of relying on pip behaviour