### PR TITLE
feat: improved support of python3

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -4,10 +4,16 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [ '2.7', '3.5', '3.6', '3.7', '3.10' ]
+        os: ['ubuntu-20.04', 'ubuntu-latest']
+        exclude:
+             - python-version: 3.5
+               os: ubuntu-latest
+             - python-version: 3.6
+               os: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     name: Build and test with Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -16,5 +16,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: |
-          python setup.py install
+          python -m pip install -r requirements.txt .
           python test.py
+          yes | python -m pip uninstall dash-hash

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build
+dash_hash.egg-info/
+dist

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 The MIT License (MIT)
 
+Copyright (c) 2016-2023 The Dash Core developers
 Copyright (c) 2014-2015 The Dash (Darkcoin) Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -7,17 +7,20 @@ Python module for Dash's X11 hashing.
 Install
 -------
 
-Python 2.7+ or 3.5+ and the associated development package (e.g., `python2-dev`) is required as well as a gcc.
+Python 3.5+ or 2.7+ and the associated development package (e.g., `python3-dev`) is required as well as a gcc.
 
-    $ sudo python setup.py install
-
+    $ pip3 install -r requirements.txt .
 
 Test
 -------
 
 After installation, test hash.
 
-    $ python test.py
+    $ python3 test.py
+
+Uninstall
+-------
+    $ pip3 uninstall dash_hash
 
 Credits
 -------

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-dash_hash (python) v1.3.2
+dash_hash (python) v1.4.0
 ===========================
 
 Python module for Dash's X11 hashing.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+setuptools
+wheel

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 dash_hash_module = Extension('dash_hash',
                                  sources = ['dashmodule.c',

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,6 @@ dash_hash_module = Extension('dash_hash',
                                include_dirs=['.', './sha3'])
 
 setup (name = 'dash_hash',
-       version = '1.3.2',
+       version = '1.4.0',
        description = 'Binding for Dash X11 proof of work hashing.',
        ext_modules = [dash_hash_module])


### PR DESCRIPTION
With modern python the setup process by an old instruction will trigger a warning:
    ```
    setup.py:1: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    ```

To avoid this (and other related warnings) were updated:
 - package `distutils.core` replaced by modern `setuptools`
 - updated README.txt to use PIP instead call setup.py directly
 - used python3 in README.txt instead python

That gives 2 extra features beside rid of warnings:
 - you can easily install dash_hash package without root permission on host
 - you can uninstall package now by pip3/python-pip easily