### PR TITLE
ci: modernize CI matrix, pin actions, and refresh docs

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Build and test with Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - run: |

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -6,17 +6,14 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [ '2.7', '3.5', '3.6', '3.7', '3.10' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
         os: ['ubuntu-20.04', 'ubuntu-22.04', 'ubuntu-latest']
-        exclude:
-             - python-version: 2.7
-               os: ubuntu-latest
-             - python-version: 3.5
-               os: ubuntu-latest
-             - python-version: 3.6
-               os: ubuntu-latest
-             - python-version: 3.7
-               os: ubuntu-latest
+        # Old Pythons are only available on ubuntu-20.04, so add them there only.
+        include:
+          - { python-version: '2.7', os: ubuntu-20.04 }
+          - { python-version: '3.5', os: ubuntu-20.04 }
+          - { python-version: '3.6', os: ubuntu-20.04 }
+          - { python-version: '3.7', os: ubuntu-20.04 }
     runs-on: ${{ matrix.os }}
     name: Build and test with Python ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,6 +1,9 @@
-name:  Build and Test C++ and Python
+name:  Build and Test Python C Extension
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ '2.7', '3.5', '3.6', '3.7', '3.10' ]
-        os: ['ubuntu-22.04', 'ubuntu-latest']
+        os: ['ubuntu-20.04', 'ubuntu-22.04', 'ubuntu-latest']
         exclude:
              - python-version: 2.7
                os: ubuntu-latest

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ '2.7', '3.5', '3.6', '3.7', '3.10' ]
-        os: ['ubuntu-20.04', 'ubuntu-latest']
+        os: ['ubuntu-22.04', 'ubuntu-latest']
         exclude:
              - python-version: 3.5
                os: ubuntu-latest

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -15,7 +15,7 @@ jobs:
           - { python-version: '3.6', os: ubuntu-20.04 }
           - { python-version: '3.7', os: ubuntu-20.04 }
     runs-on: ${{ matrix.os }}
-    name: Build and test with Python ${{ matrix.python-version }}
+    name: Build and test with Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup python

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -3,19 +3,32 @@ name:  Build and Test C++ and Python
 on: [push, pull_request]
 
 jobs:
-  build:
+  modern:
     strategy:
+      fail-fast: false
       matrix:
         python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
-        os: ['ubuntu-20.04', 'ubuntu-22.04', 'ubuntu-latest']
-        # Old Pythons are only available on ubuntu-20.04, so add them there only.
-        include:
-          - { python-version: '2.7', os: ubuntu-20.04 }
-          - { python-version: '3.5', os: ubuntu-20.04 }
-          - { python-version: '3.6', os: ubuntu-20.04 }
-          - { python-version: '3.7', os: ubuntu-20.04 }
+        os: ['ubuntu-22.04', 'ubuntu-latest']
     runs-on: ${{ matrix.os }}
-    name: Build and test with Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    name: Modern Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Setup python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: |
+          python -m pip install -r requirements.txt .
+          python test.py
+          yes | python -m pip uninstall dash-hash
+
+  legacy:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '2.7', '3.5', '3.6', '3.7' ]
+    runs-on: ubuntu-20.04
+    name: Legacy Python ${{ matrix.python-version }} on ubuntu-20.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup python

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -9,9 +9,13 @@ jobs:
         python-version: [ '2.7', '3.5', '3.6', '3.7', '3.10' ]
         os: ['ubuntu-22.04', 'ubuntu-latest']
         exclude:
+             - python-version: 2.7
+               os: ubuntu-latest
              - python-version: 3.5
                os: ubuntu-latest
              - python-version: 3.6
+               os: ubuntu-latest
+             - python-version: 3.7
                os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     name: Build and test with Python ${{ matrix.python-version }}

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -7,8 +7,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.7', '3.10', '3.11', '3.12', '3.13', '3.14' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
         os: ['ubuntu-22.04', 'ubuntu-latest']
+        include:
+          - { python-version: '3.7', os: ubuntu-22.04 }
     runs-on: ${{ matrix.os }}
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -28,3 +28,23 @@ jobs:
           python -m pip install -r requirements.txt .
           python test.py
           yes | python -m pip uninstall dash-hash
+
+  legacy:
+    # Python 2.7/3.5/3.6 are no longer published by actions/setup-python for
+    # the available runner images, so they are tested inside the official EOL
+    # Docker images, which still ship a working interpreter and gcc.
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [ 'python:2.7-buster', 'python:3.5-buster', 'python:3.6-buster' ]
+    runs-on: ubuntu-latest
+    container: ${{ matrix.image }}
+    name: ${{ matrix.image }}
+    steps:
+      # buster's glibc (2.28) is new enough to run checkout's bundled Node, so
+      # the same pinned version as the build job can be used here.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - run: |
+          python -m pip install .
+          python test.py
+          yes | python -m pip uninstall dash-hash

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14' ]
         os: ['ubuntu-22.04', 'ubuntu-latest']
         include:
           - { python-version: '3.7', os: ubuntu-22.04 }

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -3,32 +3,14 @@ name:  Build and Test C++ and Python
 on: [push, pull_request]
 
 jobs:
-  modern:
+  build:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
+        python-version: [ '3.7', '3.10', '3.11', '3.12', '3.13', '3.14' ]
         os: ['ubuntu-22.04', 'ubuntu-latest']
     runs-on: ${{ matrix.os }}
-    name: Modern Python ${{ matrix.python-version }} on ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Setup python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
-      - run: |
-          python -m pip install -r requirements.txt .
-          python test.py
-          yes | python -m pip uninstall dash-hash
-
-  legacy:
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [ '2.7', '3.5', '3.6', '3.7' ]
-    runs-on: ubuntu-20.04
-    name: Legacy Python ${{ matrix.python-version }} on ubuntu-20.04
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup python

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -3,6 +3,8 @@ name:  Build and Test Python C Extension
 on:
   push:
   pull_request:
+  schedule:
+    - cron: '17 8 * * 1'
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -6,19 +6,20 @@ Python module for Dash's X11 hashing.
 Install
 -------
 
-Python 3.7+ and the associated development package (e.g., `python3-dev`) is required as well as gcc.
+Python 3.5+ or 2.7+ and the associated development package (e.g., `python3-dev`) is required as well as gcc.
 
     pip3 install -r requirements.txt .
 
 Test
--------
+----
 
 After installation, test hash.
 
     python3 test.py
 
 Uninstall
--------
+---------
+
     pip3 uninstall dash_hash
 
 Credits

--- a/README.md
+++ b/README.md
@@ -3,24 +3,23 @@ dash_hash (python) v1.4.0
 
 Python module for Dash's X11 hashing.
 
-
 Install
 -------
 
-Python 3.5+ or 2.7+ and the associated development package (e.g., `python3-dev`) is required as well as a gcc.
+Python 3.7+ and the associated development package (e.g., `python3-dev`) is required as well as gcc.
 
-    $ pip3 install -r requirements.txt .
+    pip3 install -r requirements.txt .
 
 Test
 -------
 
 After installation, test hash.
 
-    $ python3 test.py
+    python3 test.py
 
 Uninstall
 -------
-    $ pip3 uninstall dash_hash
+    pip3 uninstall dash_hash
 
 Credits
 -------


### PR DESCRIPTION
## Summary

Modernizes the GitHub Actions workflow and refreshes the README. All previously supported Python versions remain tested — modern releases on hosted runners, and the EOL releases (2.7, 3.5, 3.6) inside official Docker images.

## CI changes

- **Modern Python (3.7–3.14):** tested via `actions/setup-python` on hosted runners (`ubuntu-22.04` and `ubuntu-latest`). Python 3.7 runs on 22.04 only (added via `include`), since newer runners don't provide it.
- **Legacy Python (2.7, 3.5, 3.6):** these are no longer published by `actions/setup-python` for the available runner images, so a separate `legacy` job runs them inside the official `python:X.Y-buster` Docker images, which still ship a working interpreter and gcc. The C extension already has Python 2 build branches, so no source changes were needed.
- **Pinned actions** to commit SHAs: `checkout` v6.0.3 (both jobs) and `setup-python` v6.2.0 (previously floating `@v2` tags). buster's glibc (2.28) is new enough to run checkout v6's bundled Node.
- **`fail-fast: false`** so one version failing doesn't cancel the rest.
- **Triggers:** added `workflow_dispatch` (manual runs) and a weekly `schedule` (Mondays 08:17 UTC) to catch breakage from runner/dependency drift.
- **Renamed** the workflow to "Build and Test Python C Extension" (was "C++ and Python" — there's no standalone C++ build).
- Job display names include the OS / container image.

## Docs

- Fixed the `Test` and `Uninstall` heading underlines.
- Dropped `$` prompts from command examples for easier copy-paste.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified installation, testing, and uninstall examples in README; Python requirement text left as-is.

* **Chores**
  * CI updated: rename, expanded test triggers, primary matrix now targets modern Python releases (3.10–3.14, plus 3.7 in an include) and a separate legacy job runs older Python releases (2.7, 3.5, 3.6).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->